### PR TITLE
PR for v1.3.1: change of communcation with yii::$app->formatter in Module

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,3 +1,9 @@
+version 1.3.1
+=============
+**Date:** 2014-10-08
+
+1. changed(Enrica): communication change with yii::$app->formatter. It provides ICU terms which have to be converted with new yii helper FormatterConverter.
+
 version 1.3.0
 =============
 **Date:** 2014-07-24

--- a/Module.php
+++ b/Module.php
@@ -11,6 +11,7 @@ namespace kartik\datecontrol;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
+use yii\helpers\FormatConverter;
 
 /**
  * Date control module for Yii Framework 2.0
@@ -199,8 +200,14 @@ class Module extends \yii\base\Module
         } else {
             $attrib = $type . 'Format';
             $format = isset(Yii::$app->formatter->$attrib) ? Yii::$app->formatter->$attrib : '';
-            return $format;
-        }
+            if (strncmp($format, 'php:', 4) === 0) {
+                return substr($format, 4);
+            } elseif ($format != ''){
+                return FormatConverter::convertDateIcuToPhp($format, $type);
+            } else {
+                throw InvalidConfigException('No display date in Module configured and formatter component not configured also.');
+            }
+        }    
     }
 
     /**


### PR DESCRIPTION
Yii has changed the formatter interface. It works with ICU standard like 'short', 'medium' etc. or 'dd/mm/yyy' or 'php:d/m/Y'. To convert Yii provides a helper class `FomatConverter`. I have modified the module class that datecontrol works again. see issue #20 
