### PR TITLE
Disable ajaxConversion in widget.

### DIFF
--- a/DateControl.php
+++ b/DateControl.php
@@ -198,10 +198,10 @@ class DateControl extends \kartik\base\InputWidget
         } else {
             $this->saveFormat = Module::parseFormat($this->saveFormat, $this->type);
         }
-        if (empty($this->displayTimezone)) {
+        if (!isset($this->displayTimezone)) {
             $this->displayTimezone = $this->_module->getDisplayTimezone();
         }
-        if (empty($this->saveTimezone)) {
+        if (!isset($this->saveTimezone)) {
             $this->saveTimezone = $this->_module->getSaveTimezone();
         }
         if ($this->autoWidget) {


### PR DESCRIPTION
This for disable ajaxConversion if by default ajaxConversion is true and saveTimezone and displayTimezone is set:

```php
'displayTimezone' => 'Europe/Minsk',
'saveTimezone' => 'UTC',
'ajaxConversion' => true,
```

Now for disable ajaxConversion of FORMAT_DATE I do following:

```php
echo $form->field($phistoryModel, 'date_wedding')->widget(DateControl::className(), [
    'type' => DateControl::FORMAT_DATE,
    'ajaxConversion' => false,
    'saveTimezone' => false,
    'displayTimezone' => false,
]);
```

if to DateControl content following code:

```php
        if (!isset($this->displayTimezone)) {
            $this->displayTimezone = $this->_module->getDisplayTimezone();
        }
        if (!isset($this->saveTimezone)) {
            $this->saveTimezone = $this->_module->getSaveTimezone();
        }
```