### PR TITLE
Only apply Timezone settings on DateTime Formats

### DIFF
--- a/controllers/ParseController.php
+++ b/controllers/ParseController.php
@@ -34,6 +34,10 @@ class ParseController extends \yii\web\Controller
             $dispTimezone = ArrayHelper::getValue($post, 'dispTimezone');
             $saveTimezone = ArrayHelper::getValue($post, 'saveTimezone');
             $settings = ArrayHelper::getValue($post, 'settings', []);
+            if (ArrayHelper::getValue($post, 'type') != DateControl::FORMAT_DATETIME) {
+                $dispTimezone = null;
+                $saveTimezone = null;
+            }
             $date = DateControl::getTimestamp($post['displayDate'], $dispFormat, $dispTimezone, $settings);
             if (empty($date) || !$date) {
                 $value = '';


### PR DESCRIPTION
I think you shouldn't apply Timezones on type Date and on type Time. You only should apply Timezones on DateTime. (That's the reason, why you call that DateTimeZone and not only DateZone or TimeZone)

I have displyTimezone Europe/Paris and saveTimezone UTC. Because of the timezone applying on type Date, the Date will converted to one day before. And after that, when I load the date. The Yii-Framework won't convert that back to Europe/Paries, because no Yii won't apply timezone on dates. Only on DateTimes.