### PR TITLE
overriding the name attribute in context of using datecontrol as INPUT_WIDGET

### DIFF
--- a/DateControl.php
+++ b/DateControl.php
@@ -268,7 +268,7 @@ class DateControl extends \kartik\base\InputWidget
             $this->options = ArrayHelper::merge($this->_widgetSettings[$this->type]['options'], $this->options);
         }
         unset($this->options['model'], $this->options['attribute']);
-        $this->options['name'] = $this->_displayAttribName;
+        isset($this->options['name']) ? : $this->options['name'] = $this->_displayAttribName;
         $this->options['value'] = $value;
         $class = $this->widgetClass;
         if (!property_exists($class, 'disabled')) {


### PR DESCRIPTION
I'm not sure of Im beeing correct here, but I cant override the name attribute using the datecontrol module as input widget in "Form Grid Builder". With the yii2-builder I build a Form-Grid which consists of one or more (multiple) model instances. To pass the correct attribute values for the $POST Array I need to override the name attribute [#103](https://github.com/kartik-v/yii2-builder/issues/103).

Do I miss something?