### PR TITLE
Enable timezone validations when using date inputs

### DIFF
--- a/DateControl.php
+++ b/DateControl.php
@@ -365,10 +365,6 @@ class DateControl extends InputWidget
         if (empty($this->saveTimezone)) {
             $this->saveTimezone = $this->_module->getSaveTimezone();
         }
-        // skip timezone validations when using date only inputs
-        if ($this->type === self::FORMAT_DATE) {
-            $this->displayTimezone = $this->saveTimezone = null;
-        }
         if ($this->autoWidget) {
             $this->_widgetSettings = [
                 self::FORMAT_DATE => ['class' => '\kartik\date\DatePicker'],


### PR DESCRIPTION
I use DatePicker input with ActiveForm and model validation enabled like this:

$form->field($model, 'date')->widget(DateControl::classname(), [
    'type'=>DateControl::FORMAT_DATE,
]); 

My configuration:
...
'timeZone' => 'Europe/Warsaw',
...

    'modules' => [
        'datecontrol' =>  [
            'class' => 'kartik\datecontrol\Module',
            'displaySettings' => [
                Module::FORMAT_DATE => 'dd-MM-yyyy',
                Module::FORMAT_TIME => 'hh:mm:ss a',
                Module::FORMAT_DATETIME => 'dd-MM-yyyy hh:mm:ss a',
            ],

            'saveSettings' => [
                Module::FORMAT_DATE => 'php:U', 
                Module::FORMAT_TIME => 'php:U',
                Module::FORMAT_DATETIME => 'php:U',
            ],

            'ajaxConversion'=>true,

            'saveTimezone' => 'UTC',
            'displayTimezone' => 'Europe/Warsaw',

            'autoWidget' => true,

            'autoWidgetSettings' => [
                Module::FORMAT_DATE => ['type'=>2, 'pluginOptions'=>['autoclose'=>true]], 
                Module::FORMAT_DATETIME => ['pluginOptions'=>['autoclose'=>true]], 
                Module::FORMAT_TIME => ['pluginOptions'=>['autoclose'=>true]], 

            ],
        ]
    ]

When I select 09-01-2017 and save form, date field in database has 1483916400 (UTC) value. 
When I reload page in date field I see 08-01-2017. I don`t have this problem when I use 
'type'=>DateControl::FORMAT_DATETIME,

Is there any reason that you don`t set timezone validations when using date input?
I think that timezone should be validated in order to correctly display the date.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-datecontrol/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.