### PR TITLE
Update composer.json to include php requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5.0",
         "kartik-v/yii2-krajee-base": ">=1.9",
         "kartik-v/php-date-formatter": ">1.3"
     },


### PR DESCRIPTION
::class notation is available only from PHP 5.5.x

I know version older than PHP 5.5 should be very outdated, but it can happen to do something on an old and (for various reason) unupdatable server. 
Having PHP requirement could save time looking for the right version of the library to use with PHP 5.4.